### PR TITLE
Complete the consistency test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+.idea/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules/
-.DS_Stor
+.DS_Store

--- a/ometiff-JavaScript/.gitignore
+++ b/ometiff-JavaScript/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Stor

--- a/ometiff-JavaScript/PixelSizeConsistency.js
+++ b/ometiff-JavaScript/PixelSizeConsistency.js
@@ -10,7 +10,7 @@ function getExif() {
 
 function convertFactor(fromUnit, toUnit) {
     if(!validunits.includes(fromUnit) || !validunits.includes(toUnit)){
-        console.log('\x1b[31mWARNING: "%s" is an invalid physicalSizeUnit\x1b[0m', fromUnit)
+        console.log('\x1b[31mWARNING: PixelSize consistency is only validated for "mm", "um" and "nm". PhysicalUnit in OME-TIFF is "%s", consistency check is skipped.\x1b[0m', fromUnit)
         process.exit(1)
     }
 

--- a/ometiff-JavaScript/PixelSizeConsistency.js
+++ b/ometiff-JavaScript/PixelSizeConsistency.js
@@ -1,30 +1,56 @@
-import ExifReader from '../../bids-validator/node_modules/exifreader/dist/exif-reader.js'
-import xml2js from '../../bids-validator/node_modules/xml2js/lib/xml2js.js'
+const ExifReader = require('exifreader')
+const parseString = require('xml2js').parseString
+
 
 function getExif() {
-    const tags = ExifReader.load("test_image.ome.tif");
+    const tags = ExifReader.load("test_image.ome.tif")
     return tags
 }
+
+function convertFactor(physicalSizeUnit) {
+    if(physicalSizeUnit === 'mm') {
+        return 1000
+    }else if(physicalSizeUnit === 'um') {
+        return 1
+    }else if(physicalSizeUnit === 'nm') {
+        return 0.001
+    }
+}
+
 getExif().then(function(result) {
     var xml = result['ImageDescription']['description']
     //console.log("\n OME-XML:", xml)
     
-
-    var parseString = xml2js.parseString;
-
     parseString(xml, function (err, output) {
-        //console.dir(output['OME']['Image'][0]['Pixels'][0]['$'])
-        console.log("\nOME-TIFF metadata\n---------------------")
-        console.log("PhysicalSizeX:", output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeX']);
-        console.log("PhysicalSizeXUnit:", output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeXUnit']);
-        console.log("PhysicalSizeY:", output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeY']);
-        console.log("PhysicalSizeYUnit:", output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeYUnit']);
-        console.log("PhysicalSizeZ:", output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeZ']);
-        console.log("PhysicalSizeZUnit:", output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeZUnit']);
-        console.log("DimensionOrder:", output['OME']['Image'][0]['Pixels'][0]['$']['DimensionOrder']);
-    });
-})
 
-//fetch("test_image.json")
-//  .then(response => response.json())
-//  .then(json => console.log(json));
+        const physicalSizeX = output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeX']
+        const physicalSizeXUnit = output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeXUnit']
+        const physicalSizeY = output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeY']
+        const physicalSizeYUnit = output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeYUnit']
+        const physicalSizeZ = output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeZ']
+        const physicalSizeZUnit = output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeZUnit']
+
+        console.log("\nOME-TIFF metadata\n---------------------")
+        console.log("PhysicalSizeX:", physicalSizeX)
+        console.log("PhysicalSizeXUnit:", physicalSizeXUnit)
+        console.log("PhysicalSizeY:", physicalSizeY)
+        console.log("PhysicalSizeYUnit:", physicalSizeYUnit)
+        console.log("PhysicalSizeZ:", physicalSizeZ)
+        console.log("PhysicalSizeZUnit:", physicalSizeZUnit)
+        console.log("DimensionOrder:", output['OME']['Image'][0]['Pixels'][0]['$']['DimensionOrder'])
+
+        let factorX = convertFactor(physicalSizeXUnit);
+        let factorY = convertFactor(physicalSizeYUnit);
+        let factorZ = convertFactor(physicalSizeZUnit);
+        let jsonData = require('./test_image.json')
+
+        let pixelSize = jsonData['PixelSize']
+
+        if (physicalSizeX * factorX !== pixelSize[0] || physicalSizeY * factorY !== pixelSize[1] || physicalSizeZ * factorZ !== pixelSize[2]) {
+            console.log("PixelSize is not consistent with PhysicalSizeX, PhysicalSizeY and PhysicalSizeZ OME metadata fields")
+        }else{
+            console.log("PixelSize is consistent with PhysicalSizeX, PhysicalSizeY and PhysicalSizeZ OME metadata fields")
+        }
+
+    })
+})

--- a/ometiff-JavaScript/PixelSizeConsistency.js
+++ b/ometiff-JavaScript/PixelSizeConsistency.js
@@ -1,25 +1,45 @@
 const ExifReader = require('exifreader')
 const parseString = require('xml2js').parseString
 
+const validunits = ['um', 'nm', 'mm']
 
 function getExif() {
     const tags = ExifReader.load("test_image.ome.tif")
     return tags
 }
 
-function convertFactor(physicalSizeUnit) {
-    if(physicalSizeUnit === 'mm') {
-        return 1000
-    }else if(physicalSizeUnit === 'um') {
-        return 1
-    }else if(physicalSizeUnit === 'nm') {
-        return 0.001
+function convertFactor(fromUnit, toUnit) {
+    if(!validunits.includes(fromUnit) || !validunits.includes(toUnit)){
+        console.log('\x1b[31mWARNING: "%s" is an invalid physicalSizeUnit\x1b[0m', fromUnit)
+        process.exit(1)
     }
+
+    if(fromUnit === toUnit) return 1
+
+    if(toUnit === 'um'){
+        if(fromUnit === 'mm') {
+            return 1000
+        }else if(fromUnit === 'nm') {
+            return 0.001
+        }
+    }else if(toUnit === 'mm'){
+        if(fromUnit === 'um') {
+            return 0.001
+        }else if(fromUnit === 'nm') {
+            return 0.000001
+        }
+    }else if(toUnit === 'nm'){
+        if(fromUnit === 'mm') {
+            return 1000000
+        }else if(fromUnit === 'um') {
+            return 1000
+        }
+    }
+
 }
 
 getExif().then(function(result) {
     var xml = result['ImageDescription']['description']
-    //console.log("\n OME-XML:", xml)
     
     parseString(xml, function (err, output) {
 
@@ -30,26 +50,31 @@ getExif().then(function(result) {
         const physicalSizeZ = output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeZ']
         const physicalSizeZUnit = output['OME']['Image'][0]['Pixels'][0]['$']['PhysicalSizeZUnit']
 
-        console.log("\nOME-TIFF metadata\n---------------------")
-        console.log("PhysicalSizeX:", physicalSizeX)
-        console.log("PhysicalSizeXUnit:", physicalSizeXUnit)
-        console.log("PhysicalSizeY:", physicalSizeY)
-        console.log("PhysicalSizeYUnit:", physicalSizeYUnit)
-        console.log("PhysicalSizeZ:", physicalSizeZ)
-        console.log("PhysicalSizeZUnit:", physicalSizeZUnit)
-        console.log("DimensionOrder:", output['OME']['Image'][0]['Pixels'][0]['$']['DimensionOrder'])
-
-        let factorX = convertFactor(physicalSizeXUnit);
-        let factorY = convertFactor(physicalSizeYUnit);
-        let factorZ = convertFactor(physicalSizeZUnit);
+        console.log("\nOME-TIFF metadata")
+        const metadata = {
+            "PhysicalSizeX" : physicalSizeX,
+            "PhysicalSizeXUnit" : physicalSizeXUnit,
+            "PhysicalSizeY" : physicalSizeY,
+            "PhysicalSizeYUnit" : physicalSizeYUnit,
+            "PhysicalSizeZ" : physicalSizeZ,
+            "PhysicalSizeZUnit" : physicalSizeZUnit,
+            "DimensionOrder" : output['OME']['Image'][0]['Pixels'][0]['$']['DimensionOrder']
+        }
+        console.table(metadata)
+        
         let jsonData = require('./test_image.json')
-
         let pixelSize = jsonData['PixelSize']
+        let physicalSizeUnit = jsonData['PixelSizeUnits']
+
+        let factorX = convertFactor(physicalSizeXUnit, physicalSizeUnit);
+        let factorY = convertFactor(physicalSizeYUnit, physicalSizeUnit);
+        let factorZ = convertFactor(physicalSizeZUnit, physicalSizeUnit);
 
         if (physicalSizeX * factorX !== pixelSize[0] || physicalSizeY * factorY !== pixelSize[1] || physicalSizeZ * factorZ !== pixelSize[2]) {
-            console.log("PixelSize is not consistent with PhysicalSizeX, PhysicalSizeY and PhysicalSizeZ OME metadata fields")
+            console.log("\x1b[31m%s\x1b[0m", "PixelSize is not consistent with PhysicalSizeX, PhysicalSizeY and PhysicalSizeZ OME metadata fields")
+            console.log("\x1b[31mpixelSize in JSON is %s, the converted physicalSize from OME-XML is [%s, %s, %s]\x1b[0m", pixelSize, physicalSizeX * factorX, physicalSizeY * factorY, physicalSizeZ * factorZ)
         }else{
-            console.log("PixelSize is consistent with PhysicalSizeX, PhysicalSizeY and PhysicalSizeZ OME metadata fields")
+            console.log("\x1b[36m%s\x1b[0m", "PixelSize is consistent with PhysicalSizeX, PhysicalSizeY and PhysicalSizeZ OME metadata fields")
         }
 
     })

--- a/ometiff-JavaScript/README.md
+++ b/ometiff-JavaScript/README.md
@@ -1,15 +1,14 @@
 # Instructions
 
-ExifReader (https://github.com/mattiasw/ExifReader) is a JavaScript library used to read images metadata. To install it:
-- Open your command window
-- Reach the directory `cd bids-validator\node_modules`
-- Type `npm install exifreader --save`
-- Type `npm install esm`<br>
-`esm` stands for EcmaScript Modules. It helps with the module importation and permits the use of the flag `-r esm`. Without it, we get a SyntaxError when running our test script.
-- Type `npm install xml2js`
-xml2js is a package that gives the ability to convert a XML to a JavaScript object. It will help to easily access the OME-TIFF metadata fields.
-- With the command `cd` in your console, reach the folder where the metadata read script is (`C:\Users\<my_user>\ometiff-tests\ometiff-JavaScript`)
-- Type `node -r esm PixelSizeConsistency.js` 
-The complete OME-XML of ‘test_image.ome.tif’ will appear in the console, as well as the `<Image><Pixels>` fields. Those fields are interesting to validate the consistency of the PixelSize JSON field as well as its units (i.e. “um”).
+ExifReader (https://github.com/mattiasw/ExifReader) is a JavaScript library used to parse image files and extracts the metadata.
+
+xml2js (https://github.com/Leonidas-from-XIV/node-xml2js) is a package that gives the ability to convert an XML to a JavaScript object. It will help to easily access the OME-TIFF metadata fields.
+
+To install them
+- Open your command window/terminal
+- Reach the directory `cd ometiff-tests\ometiff-JavaScript`
+- Type `npm install` to install exifreader and xml2js
+- Type `node PixelSizeConsistency.js` to run the metadata read script.
+The complete OME-XML of `test_image.ome.tif` will appear in the console, as well as the `<Image><Pixels>` fields. Those fields are interesting to validate the consistency of the PixelSize JSON field as well as its units (i.e. “um”).
 
 

--- a/ometiff-JavaScript/package-lock.json
+++ b/ometiff-JavaScript/package-lock.json
@@ -1,0 +1,92 @@
+{
+  "name": "ometiff-javascript",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ometiff-javascript",
+      "dependencies": {
+        "exifreader": "^4.1.0",
+        "xml2js": "^0.4.23"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/exifreader": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/exifreader/-/exifreader-4.1.0.tgz",
+      "integrity": "sha512-LzTW96ubaHRSWVD6bgANpZgWGHdtA/jsIdVjFVhDDN6k60wid8U6b3cIWSGTfRePjZlwvyt4nt12bIQ5ywUrBw==",
+      "hasInstallScript": true,
+      "optionalDependencies": {
+        "@xmldom/xmldom": "^0.7.5"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@xmldom/xmldom": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+      "optional": true
+    },
+    "exifreader": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/exifreader/-/exifreader-4.1.0.tgz",
+      "integrity": "sha512-LzTW96ubaHRSWVD6bgANpZgWGHdtA/jsIdVjFVhDDN6k60wid8U6b3cIWSGTfRePjZlwvyt4nt12bIQ5ywUrBw==",
+      "requires": {
+        "@xmldom/xmldom": "^0.7.5"
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    }
+  }
+}

--- a/ometiff-JavaScript/package.json
+++ b/ometiff-JavaScript/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ometiff-javascript",
+  "dependencies": {
+    "exifreader": "^4.1.0",
+    "xml2js": "^0.4.23"
+  }
+}


### PR DESCRIPTION
## Description
This PR aims to complete the consistency test script `PixelSizeConsistency.js`. 

1. Instead of using `import` to load the external packages, `require` may be a better option since it could eliminate `esm` as a dependency. Also, since ometiff-tests is an independent repository, it should not rely on dependencies from another repository. In this case, we introduced a package.json and listed two dependencies in this file to make users install all `exifreader` and `xml2js` inside this repository.
2. Added gitignore file.
3. Updated README file to fit the new features.